### PR TITLE
Install migrate_upgrade 8.x-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use this module and the directions below as a starting point to easily get your 
 
 ## SETUP
 
-1. Setup both your Drupal 7 and Drupal 8 sites in Lando
+1. Setup both your Drupal 7 and Drupal 8 sites in Lando.  Configure the Drupal 8 site to install Drush 9.
 2. Copy the .lando.yml file in this repo to your Drupal 8 site root (change the app name)
 3. Export your Drupal 7 DB with ```lando db-export dump.sql.gz```
 4. Copy the settings.local.php file in this repo to your Drupal 8 sites/default folder.
@@ -13,8 +13,8 @@ Use this module and the directions below as a starting point to easily get your 
 
 ```bash
 lando composer require 'drupal/migrate_plus:^4.2'
-lando composer require 'drupal/migrate_tools:^4.3'
-lando composer require 'drupal/migrate_upgrade:^3.0'
+lando composer require 'drupal/migrate_tools:^4.5'
+lando composer require 'drupal/migrate_upgrade:~3.0.0'
 ```
 
 7. Enable this module.


### PR DESCRIPTION
The 8.x-3.1 version of migrate_upgrade requires Drush 10 which causes pain.