### PR TITLE
fixing Drupal coding violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Drupal 8 Migration Boilerplate 
 
-Use this module and the directions below as a starting point to easily get your Drupal 6/7 sites into Drupal 8.
+Use this module and the directions below as a 
+starting point to easily get your Drupal 6/7 sites into Drupal 8.
 
 ## SETUP
 
-1. Setup both your Drupal 7 and Drupal 8 sites in Lando.  Configure the Drupal 8 site to install Drush 9.
-2. Copy the .lando.yml file in this repo to your Drupal 8 site root (change the app name)
+1. Setup both your Drupal 7 and Drupal 8 sites in Lando. 
+Configure the Drupal 8 site to install Drush 9.
+2. Copy the .lando.yml file in this repo to your Drupal 8 site root 
+(change the app name)
 3. Export your Drupal 7 DB with ```lando db-export dump.sql.gz```
-4. Copy the settings.local.php file in this repo to your Drupal 8 sites/default folder.
-5. Import the Drupal 7 DB into the Drupal 8 Site with ```lando db-import --host=d7db --user=drupal7db dump.sql.gz```
+4. Copy the settings.local.php file in this repo to your 
+Drupal 8 sites/default folder.
+5. Import the Drupal 7 DB into the Drupal 8 Site with 
+```lando db-import --host=d7db --user=drupal7db dump.sql.gz```
 6. Run this in your Drupal 8 project root:
 
 ```bash

--- a/migration_boilerplate.module
+++ b/migration_boilerplate.module
@@ -37,7 +37,7 @@ function migration_boilerplate_migrate_prepare_row(Row $row, MigrateSourceInterf
     // Put stuff here.
   ];
 
-  // Fields to skip for now
+  // Fields to skip for now.
   $skip_fields = [
     // Put stuff here.
   ];
@@ -47,7 +47,7 @@ function migration_boilerplate_migrate_prepare_row(Row $row, MigrateSourceInterf
     // Put stuff here.
   ];
 
-  // Vocab Skip
+  // Vocab Skip.
   $vocab_skip = [
     // Put stuff here.
   ];
@@ -96,7 +96,8 @@ function migration_boilerplate_migrate_prepare_row(Row $row, MigrateSourceInterf
       $instances = $row->getSourceProperty('instances');
       switch ($instances[0]['bundle']) {
         case 'OLD_BUNDLE':
-          $instances[0]['bundle'] = 'NEW_BUNDLE'; // Merge fields to person type.
+          $instances[0]['bundle'] = 'NEW_BUNDLE';
+          // Merge fields to person type.
           $row->setSourceProperty('instances', $instances);
           break;
       }
@@ -119,16 +120,18 @@ function migration_boilerplate_migrate_prepare_row(Row $row, MigrateSourceInterf
       $instances = $row->getSourceProperty('instances');
       switch ($instances[0]['bundle']) {
         case 'OLD_BUNDLE':
-          $instances[0]['bundle'] = 'NEW_BUNDLE'; // Merge fields to person type.
+          $instances[0]['bundle'] = 'NEW_BUNDLE';
+          // Merge fields to person type.
           $row->setSourceProperty('instances', $instances);
           break;
       }
 
-    // Move a field to a new type / bundle example continued.
+      // Move a field to a new type / bundle example continued.
       $bundle = $row->getSourceProperty('bundle');
       switch ($bundle) {
         case 'OLD_BUNDLE':
-          $row->setSourceProperty('bundle', 'NEW_BUNDLE'); // Merge fields to person type.
+          $row->setSourceProperty('bundle', 'NEW_BUNDLE');
+          // Merge fields to person type.
           break;
       }
 
@@ -178,7 +181,7 @@ function migration_boilerplate_migrate_prepare_row(Row $row, MigrateSourceInterf
     case 'upgrade_d7_node_NAME':
       $title = $row->getSourceProperty('title');
       if (stripos($title, 'sad') !== FALSE) {
-        // Skip old sad posts
+        // Skip old sad posts.
         throw new MigrateSkipRowException('', TRUE);
       }
       break;

--- a/settings.local.php
+++ b/settings.local.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Example for adding a second database below.
+ */
+
 $databases['default']['default'] = [
   'database' => 'drupal8',
   'username' => 'drupal8',

--- a/src/Plugin/migrate/process/CheckValue.php
+++ b/src/Plugin/migrate/process/CheckValue.php
@@ -20,7 +20,6 @@ use Drupal\migrate\Row;
  *   plugin: check_value
  *   source: text
  * @endcode
- *
  */
 class CheckValue extends ProcessPluginBase {
 
@@ -30,4 +29,5 @@ class CheckValue extends ProcessPluginBase {
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
     var_dump($value);
   }
+
 }


### PR DESCRIPTION
Fixed the following errors and warnings that were showing up in my circleci static tests...


FILE: ...ps_8_composer/web/modules/custom/migration_boilerplate/README.md
----------------------------------------------------------------------
FOUND 0 ERRORS AND 5 WARNINGS AFFECTING 5 LINES
----------------------------------------------------------------------
  3 | WARNING | Line exceeds 80 characters; contains 111 characters
  7 | WARNING | Line exceeds 80 characters; contains 105 characters
  8 | WARNING | Line exceeds 80 characters; contains 89 characters
 10 | WARNING | Line exceeds 80 characters; contains 87 characters
 11 | WARNING | Line exceeds 80 characters; contains 116 characters
----------------------------------------------------------------------


FILE: ...odules/custom/migration_boilerplate/migration_boilerplate.module
----------------------------------------------------------------------
FOUND 7 ERRORS AND 3 WARNINGS AFFECTING 7 LINES
----------------------------------------------------------------------
  40 | ERROR   | [x] Inline comments must end in full-stops,
     |         |     exclamation marks, question marks, colons, or
     |         |     closing parentheses
  50 | ERROR   | [x] Inline comments must end in full-stops,
     |         |     exclamation marks, question marks, colons, or
     |         |     closing parentheses
  99 | WARNING | [ ] Line exceeds 80 characters; contains 81
     |         |     characters
  99 | ERROR   | [x] Comments may not appear after statements
 122 | WARNING | [ ] Line exceeds 80 characters; contains 81
     |         |     characters
 122 | ERROR   | [x] Comments may not appear after statements
 127 | ERROR   | [x] Line indented incorrectly; expected 6 spaces,
     |         |     found 4
 131 | WARNING | [ ] Line exceeds 80 characters; contains 90
     |         |     characters
 131 | ERROR   | [x] Comments may not appear after statements
 181 | ERROR   | [x] Inline comments must end in full-stops,
     |         |     exclamation marks, question marks, colons, or
     |         |     closing parentheses
----------------------------------------------------------------------
PHPCBF CAN FIX THE 7 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: .../migration_boilerplate/src/Plugin/migrate/process/CheckValue.php
----------------------------------------------------------------------
FOUND 7 ERRORS AFFECTING 7 LINES
----------------------------------------------------------------------
 25 | ERROR | [x] Opening brace should be on the same line as the
    |       |     declaration
 27 | ERROR | [x] Line indented incorrectly; expected 2 spaces, found
    |       |     4
 30 | ERROR | [x] Line indented incorrectly; expected 2 spaces, found
    |       |     4
 31 | ERROR | [x] Opening brace should be on the same line as the
    |       |     declaration
 32 | ERROR | [x] Line indented incorrectly; expected 4 spaces, found
    |       |     8
 33 | ERROR | [x] Line indented incorrectly; expected 2 spaces, found
    |       |     4
 34 | ERROR | [x] Expected 1 newline at end of file; 0 found
----------------------------------------------------------------------
PHPCBF CAN FIX THE 7 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: ...oser/web/modules/custom/migration_boilerplate/settings.local.php
----------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 4 LINES
----------------------------------------------------------------------
  1 | ERROR | [x] Missing file doc comment
 26 | ERROR | [x] TRUE, FALSE and NULL must be uppercase; expected
    |       |     "FALSE" but found "false"
 27 | ERROR | [x] TRUE, FALSE and NULL must be uppercase; expected
    |       |     "FALSE" but found "false"
 31 | ERROR | [x] TRUE, FALSE and NULL must be uppercase; expected
    |       |     "FALSE" but found "false"
 31 | ERROR | [x] Expected 1 newline at end of file; 0 found
----------------------------------------------------------------------
PHPCBF CAN FIX THE 5 MARKED SNIFF VIOLATIONS AUTOMATICALLY